### PR TITLE
move overrides.css farther down the cascade

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -32,7 +32,7 @@
   function theme_enqueue_styles() {
      wp_register_script( 'header-helper', get_stylesheet_directory_uri() . '/header_helper.js', array( 'jquery' ));
      wp_register_style('parent-style', get_template_directory_uri() . '/style.css');
-     wp_register_style('override-style', get_stylesheet_directory_uri() . '/overrides.css');
+     wp_register_style('override-style', get_stylesheet_directory_uri() . '/overrides.css', array('quest-all-css', 'Quest-style'));
      wp_enqueue_style( 'parent-style' );
      wp_enqueue_style( 'override-style');
      wp_enqueue_script( 'header-helper');


### PR DESCRIPTION
it would seem overrides should be as far down the cascade as possible; currently, however, it is still above two of the base quest theme stylesheets: `quest-all-css` and `quest-style` ... this moves it below them.
