### PR TITLE
Move overrides.css into subfolder and implement overrides/functions.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 analytics.php
 overrides.css
 .DS_Store
+.gitmodules
+overrides/

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Insert your google analytics code like so:
       ";
 ```
 
-If a project is going to need to override some of the CSS, you can add an overrides.css file (which is ignored by git) and so won't be overwritten by future git pulls from the main repo.
+If you would like to override some of the functionality and styles or this
+child theme you may create a sub-directory named `overrides`.  This directory
+will be ignored by git and your changes won't be overwritten by future git pulls
+from the main repo.  Additionally, you can initialize this repository as a
+git-submodule and track your own changes in your own repo.
 
 ```
-  cd /wp-content/themes/quest-child
-  touch overrides.css
+  cd wp-content/themes/quest-child
+  mkdir overrides
+  touch overrides/style.css
+  echo "<?php //silence is golden" > overrides/functions.php
 ```
 
 

--- a/functions.php
+++ b/functions.php
@@ -30,12 +30,19 @@
 
 
   function theme_enqueue_styles() {
-     wp_register_script( 'header-helper', get_stylesheet_directory_uri() . '/header_helper.js', array( 'jquery' ));
-     wp_register_style('parent-style', get_template_directory_uri() . '/style.css');
-     wp_register_style('override-style', get_stylesheet_directory_uri() . '/overrides.css', array('quest-all-css', 'Quest-style'));
-     wp_enqueue_style( 'parent-style' );
-     wp_enqueue_style( 'override-style');
-     wp_enqueue_script( 'header-helper');
+    wp_register_script('header-helper', get_stylesheet_directory_uri() . '/header_helper.js', array( 'jquery' ));
+    wp_register_style('parent-style', get_template_directory_uri() . '/style.css');
+
+    // check for custom override styles
+    if (file_exists(dirname(__FILE__) . '/overrides/style.css')) {
+      wp_register_style('override-style', get_stylesheet_directory_uri() . '/overrides/style.css', array('quest-all-css', 'Quest-style'));
+    } elseif (file_exists(dirname(__FILE__) . '/overrides.css')) {
+      wp_register_style('override-style', get_stylesheet_directory_uri() . '/overrides.css', array('quest-all-css', 'Quest-style'));
+    }
+
+    wp_enqueue_style('parent-style');
+    wp_enqueue_style('override-style');
+    wp_enqueue_script('header-helper');
   }
   add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
 

--- a/functions.php
+++ b/functions.php
@@ -849,3 +849,8 @@ function quest_breadcrumb() {
 
   echo "</ul>";
 }
+
+// custom functions.php file allowed in overrides folder
+if (file_exists(dirname(__FILE__) . '/overrides/functions.php')) {
+  require_once('overrides/functions.php');
+}


### PR DESCRIPTION
Implementing the sub-folder git-submodule concept with this child-theme.  

Styles and functions can be stored safely in the `overrides` folder and it can be initialized as a submodule (if desired).

Moves `overrides.css` into a subfolder (and changes naming convention to `style.css` to match.  Legacy `overrides.css` files will still be loaded if they exist.

Fixes #3 
